### PR TITLE
Visual changes and ability to get user popout

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ class UserIDInfo extends Plugin {
     startPlugin() {
         powercord.api.commands.registerCommand({
             command: 'userid',
-            aliases: ['useridinfo','idinfo'],
+            aliases: ['useridinfo', 'idinfo'],
             label: 'UserID Info',
             usage: '{c} <id>',
             description: 'Lookup user info from a user id',
@@ -16,24 +16,45 @@ class UserIDInfo extends Plugin {
 
     async getInfo(id) {
         try {
-        let userObject = await (await require('powercord/webpack').getModule(['acceptAgreements','getUser'])).getUser(String(id));
-        let userName = userObject['username']+'#'+userObject['discriminator'];
-        let avatarURL = userObject['avatarURL'];
-        let isBot = String(userObject['bot']);
-        let resultText = 'ID = '+id+'\nUsername = '+userName+'\nAvatar = '+avatarURL+'\nBot = '+isBot;
-        const embed = {
-            type: 'rich',
-            title: `UserID Lookup`,
-            description: resultText
+            let userObject = await (await require('powercord/webpack').getModule(['acceptAgreements', 'getUser'])).getUser(String(id));
+            let userName = userObject['username'] + '#' + userObject['discriminator'];
+            let avatarURL = userObject['avatarURL'];
+            let isBot = String(userObject['bot']);
+            const embed = {
+                type: 'rich',
+                title: `UserID Lookup for ${userName}`,
+                fields: [
+                    {
+                        name: 'ID',
+                        value: `${id}`,
+                        inline: true
+                    }, {
+                        name: 'Tag',
+                        value: `<@${id}>`,
+                        inline: true
+                    }, {
+                        name: 'Username',
+                        value: userName,
+                        inline: true
+                    }, {
+                        name: 'Bot',
+                        value: `${isBot}`,
+                        inline: true
+                    }, {
+                        name: 'Avatar',
+                        value: avatarURL,
+                        inline: true
+                    }
+                ]
+            }
+            return {
+                result: embed,
+                embed: true
+            }
         }
-        return {
-               result:embed,
-               embed:true
+        catch (err) {
+            return { result: 'Incorrect UserID.' }
         }
-    }
-    catch(err) {
-        return {result:'Incorrect UserID.'}
-    }
     }
 
     pluginWillUnload() {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const { Plugin } = require('powercord/entities');
+
 class UserIDInfo extends Plugin {
     startPlugin() {
         powercord.api.commands.registerCommand({
@@ -16,36 +18,34 @@ class UserIDInfo extends Plugin {
         try {
             let userObject = await (await require('powercord/webpack').getModule(['acceptAgreements', 'getUser'])).getUser(String(id));
             let userName = userObject['username'] + '#' + userObject['discriminator'];
+            let avatarURL = userObject['avatarURL'];
             if (userObject['avatarURL'].includes('assets')) {
                 let avatarURL = 'https://canary.discord.com' + userObject['avatarURL'];
-            } else {
-                let avatarURL = userObject['avatarURL'];
             }
             let isBot = String(userObject['bot']);
-            let resultText = 'ID = ' + id + '\nUsername = ' + userName + '\nAvatar = ' + avatarURL + '\nBot = ' + isBot;
             const embed = {
                 type: 'rich',
                 title: `UserID Lookup for ${userName}`,
                 fields: [{
                     name: 'ID',
                     value: `${id}`,
-                    inline: true
+                    inline: false
                 }, {
                     name: 'Tag',
                     value: `<@${id}>`,
-                    inline: true
+                    inline: false
                 }, {
                     name: 'Username',
                     value: userName,
-                    inline: true
+                    inline: false
                 }, {
                     name: 'Bot',
                     value: `${isBot}`,
-                    inline: true
+                    inline: false
                 }, {
                     name: 'Avatar',
                     value: avatarURL,
-                    inline: true
+                    inline: false
                 }]
             }
             return {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const { Plugin } = require('powercord/entities');
-
 class UserIDInfo extends Plugin {
     startPlugin() {
         powercord.api.commands.registerCommand({
@@ -18,42 +16,46 @@ class UserIDInfo extends Plugin {
         try {
             let userObject = await (await require('powercord/webpack').getModule(['acceptAgreements', 'getUser'])).getUser(String(id));
             let userName = userObject['username'] + '#' + userObject['discriminator'];
-            let avatarURL = userObject['avatarURL'];
+            if (userObject['avatarURL'].includes('assets')) {
+                let avatarURL = 'https://canary.discord.com' + userObject['avatarURL'];
+            } else {
+                let avatarURL = userObject['avatarURL'];
+            }
             let isBot = String(userObject['bot']);
+            let resultText = 'ID = ' + id + '\nUsername = ' + userName + '\nAvatar = ' + avatarURL + '\nBot = ' + isBot;
             const embed = {
                 type: 'rich',
                 title: `UserID Lookup for ${userName}`,
-                fields: [
-                    {
-                        name: 'ID',
-                        value: `${id}`,
-                        inline: true
-                    }, {
-                        name: 'Tag',
-                        value: `<@${id}>`,
-                        inline: true
-                    }, {
-                        name: 'Username',
-                        value: userName,
-                        inline: true
-                    }, {
-                        name: 'Bot',
-                        value: `${isBot}`,
-                        inline: true
-                    }, {
-                        name: 'Avatar',
-                        value: avatarURL,
-                        inline: true
-                    }
-                ]
+                fields: [{
+                    name: 'ID',
+                    value: `${id}`,
+                    inline: true
+                }, {
+                    name: 'Tag',
+                    value: `<@${id}>`,
+                    inline: true
+                }, {
+                    name: 'Username',
+                    value: userName,
+                    inline: true
+                }, {
+                    name: 'Bot',
+                    value: `${isBot}`,
+                    inline: true
+                }, {
+                    name: 'Avatar',
+                    value: avatarURL,
+                    inline: true
+                }]
             }
             return {
                 result: embed,
                 embed: true
             }
-        }
-        catch (err) {
-            return { result: 'Incorrect UserID.' }
+        } catch (err) {
+            return {
+                result: 'Incorrect UserID.'
+            }
         }
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,6 @@
     "name": "UserID Info",
     "description": "Grabs info about a UserID and then shows it to you.",
     "author": "webtax#9393",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "license": "MIT"
   }


### PR DESCRIPTION
I made some changes to the visuals of the embed that is sent. Mainly using fields instead of just the description. I also added the tag field which displays the user tag in mention format. This way, if you lookup a user in the same guild you run the command in, you can access their user pop out allowing you to see their roles, status, notes and access their user module. I also made the indenting consistent.