### PR TITLE
Adds date and time target account was created

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,9 @@ class UserIDInfo extends Plugin {
     async getInfo(id) {
         try {
             let userObject = await (await require('powercord/webpack').getModule(['acceptAgreements', 'getUser'])).getUser(String(id));
-            let userName = userObject['username'] + '#' + userObject['discriminator'];
+            let userName = userObject['tag'];
             let avatarURL = userObject['avatarURL'];
+            let createdAt = userObject['createdAt']
             if (userObject['avatarURL'].includes('assets')) {
                 avatarURL = 'https://canary.discord.com' + userObject['avatarURL'];
             }
@@ -46,6 +47,10 @@ class UserIDInfo extends Plugin {
                     name: 'Avatar',
                     value: avatarURL,
                     inline: false
+                }, {
+                    name: 'Created at',
+                    value: createdAt.toString(),
+                    inline: false
                 }]
             }
             return {
@@ -53,6 +58,7 @@ class UserIDInfo extends Plugin {
                 embed: true
             }
         } catch (err) {
+            console.error(err)
             return {
                 result: 'Incorrect UserID.'
             }


### PR DESCRIPTION
This PR adds the `Created at` field. It shows the date and time the target account was created in the users local time zone. It also adds a stack trace when an error occurs so debugging can occur. 